### PR TITLE
Remove $scope.$emit('hide-menu'); fixes #2662

### DIFF
--- a/src/js/core/directives/ui-grid-menu.js
+++ b/src/js/core/directives/ui-grid-menu.js
@@ -236,8 +236,6 @@ function ($compile, $timeout, $window, $document, gridUtil, uiGridConstants) {
               }
 
               $scope.action.call(context, $event, title);
-
-              $scope.$emit('hide-menu');
             }
           };
 


### PR DESCRIPTION
Removing this line of code keeps the menu open until the user is done with it. This allows for multiple actions while the menu stays open.
